### PR TITLE
Change ServiceStartMode to match that of the old automatic service

### DIFF
--- a/ProjectInstaller.Designer.cs
+++ b/ProjectInstaller.Designer.cs
@@ -43,7 +43,7 @@
             this.serviceInstaller.ServicesDependedOn = new string[] {
         "Dhcp",
         "tap0901"};
-            this.serviceInstaller.StartType = System.ServiceProcess.ServiceStartMode.Automatic;
+            this.serviceInstaller.StartType = System.ServiceProcess.ServiceStartMode.Manual;
             // 
             // ProjectInstaller
             // 


### PR DESCRIPTION
The old openvpnserv.exe's "automatic" part has always had its StartMode set to "manual". We should retain this behavior in openvpnserv2, so that previously inactive (=manually started) OpenVPN connections do not suddenly start launching without user consent.
