### PR TITLE
Do not start OpenVPNService at install time

### DIFF
--- a/OpenVpnService.csproj
+++ b/OpenVpnService.csproj
@@ -25,7 +25,7 @@
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <ApplicationVersion>1.1.0.%2a</ApplicationVersion>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>

--- a/Service.cs
+++ b/Service.cs
@@ -179,7 +179,6 @@ namespace OpenVpn
                 try
                 {
                     ProjectInstaller.Install();
-                    ProjectInstaller.Start();
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Startup mode had been set to "manual" earlier, but "openvpnserv2.exe -install"
option still attempted to launch the service. This failed if tap-windows6 was
not yet usable, as is the case when using the official OpenVPN installers. This
commit also bumps version to 1.1.0.0 to make it clear that the behavior has
changed.

Signed-off-by: Samuli Seppänen samuli@openvpn.net
